### PR TITLE
V15 updates, Navigation.unauthorized and Headers.makeAsync

### DIFF
--- a/src/GreenfinityNext_Navigation.res
+++ b/src/GreenfinityNext_Navigation.res
@@ -8,6 +8,8 @@ external redirect: (string, ~type_: type_=?) => unit = "redirect"
 @module("next/navigation")
 external notFound: unit => unit = "notFound"
 @module("next/navigation")
+external unauthorized: unit => unit = "unauthorized"
+@module("next/navigation")
 external useSelectedLayoutSegment: (~parallelRoutesKey: string=?) => string =
   "useSelectedLayoutSegment"
 @module("next/navigation")

--- a/src/GreenfinityNext_Next.res
+++ b/src/GreenfinityNext_Next.res
@@ -322,10 +322,14 @@ module Image = {
 
 module Headers = {
   type t
-  @new @module("next/headers") external make: unit => t = "headers"
+  @deprecated("Use makePromise instead and await the result.") @new @module("next/headers")
+  external make: unit => t = "headers"
+  @new @module("next/headers") external makeAsync: unit => promise<t> = "headers"
   // workaround for "cannot be used from client component" error
   @module("./GreenfinityNext_Next.mjs")
+  @deprecated("Use makePromiseWithRequire instead and await the result.")
   external makeWithRequire: unit => t = "headersMakeWithRequire"
+  external makeAsyncWithRequire: unit => promise<t> = "headersMakeWithRequire"
   @send external _get: (t, string) => Js.Nullable.t<string> = "get"
   let get = (headers, k) => headers->_get(k)->Js.Nullable.toOption
   @send external keys: t => Js.Array.array_like<string> = "keys"


### PR DESCRIPTION
- add Navigation.unauthorized
- add Next.Headers.makeAsync
- add Next.Headers.makeAsyncWithRequire
- deprecate Next.Headers.make
- deprecate Next.Headers.makeWithRequire

In fact, the headers object creation is changed to async from version 15 of nextjs. The old method won't work, but for idiomatic reasons the name is changed to `makeAsync`.