### PR TITLE
Update to rescript v12.0.0-beta.4

### DIFF
--- a/.github/workflows/github-action-acceptance.yaml
+++ b/.github/workflows/github-action-acceptance.yaml
@@ -24,5 +24,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
-      - run: yarn rescript:build
+      - run: yarn rescript:build:dev
       - run: yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ lib/js/*
 !lib/js/src
 coverage
 .coveralls.yml
+**/lib

--- a/__tests__/Example_vitest.res
+++ b/__tests__/Example_vitest.res
@@ -2,7 +2,6 @@ open Vitest
 
 describe("it", () => {
   open Expect
-  open! Expect.Operators
 
   test("works", () => {
     true->expect->toEqual(true)

--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "changelog": "yarn auto-changelog -p && git add HISTORY.md",
     "build": "yarn rescript:build",
     "rescript:clean": "yarn rescript clean",
-    "rescript:build": "yarn rescript build -with-deps",
-    "rescript:dev": "yarn rescript build -with-deps -w",
+    "rescript:build": "yarn rescript build",
+    "rescript:build:dev": "yarn rescript build --dev",
+    "rescript:dev": "yarn rescript watch --dev",
     "test": "yarn vitest --run --coverage --allow-only",
     "test:dev": "yarn vitest",
     "yalc:dev": "yarn rescript:dev & yarn nodemon -x \"yalc push\"",
@@ -34,17 +35,17 @@
   },
   "preferUnplugged": true,
   "peerDependencies": {
-    "@greenlabs/ppx-spice": "0.2.2",
-    "@rescript/react": "^0.12.0-alpha.3",
+    "@greenlabs/ppx-spice": "0.2.8",
+    "@rescript/react": "^0.14.0-rc.1",
     "@vercel/functions": "^2.0.0",
     "next": "^15.3.1",
     "next-auth": "^4.24.11",
-    "rescript": "^11.1.0"
+    "rescript": "^12.0.0-beta.4"
   },
   "devDependencies": {
-    "@greenfinity/rescript-vitest": "^0.1.0",
-    "@greenlabs/ppx-spice": "0.2.2",
-    "@rescript/react": "^0.12.0-alpha.3",
+    "@greenfinity/rescript-vitest": "^0.2.0",
+    "@greenlabs/ppx-spice": "0.2.8",
+    "@rescript/react": "^0.14.0-rc.1",
     "@vercel/functions": "^2.0.0",
     "@vitest/coverage-v8": "2.1.8",
     "auto-changelog": "^2.4.0",
@@ -56,7 +57,7 @@
     "prettier": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "rescript": "^11.1.0",
+    "rescript": "^12.0.0-beta.4",
     "vitest": "^2.1.8"
   },
   "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"

--- a/rescript.json
+++ b/rescript.json
@@ -2,7 +2,7 @@
   "name": "@greenfinity/rescript-next",
   "jsx": { "version": 4, "mode": "classic" },
   "namespace": false,
-  "bsc-flags": ["-bs-no-version-header", "-bs-super-errors"],
+  "compiler-flags": ["-bs-no-version-header"],
   "suffix": ".bs.mjs",
   "package-specs": {
     "module": "esmodule",
@@ -23,7 +23,7 @@
     "number": "-44",
     "error": "+101"
   },
-  "bs-dependencies": ["@rescript/react", "@greenlabs/ppx-spice"],
+  "dependencies": ["@rescript/react", "@greenlabs/ppx-spice"],
   "ppx-flags": ["@greenlabs/ppx-spice/ppx"],
-  "bs-dev-dependencies": ["@greenfinity/rescript-vitest"]
+  "dev-dependencies": ["@greenfinity/rescript-vitest"]
 }

--- a/src/GreenfinityNext_AppMiddleware.res
+++ b/src/GreenfinityNext_AppMiddleware.res
@@ -6,6 +6,6 @@ let default: (NextRequest.t, 'a) => 'b = async (req, processIt) => {
   try await (await (await req->NextRequest.json)->processIt)->NextResponse.json catch {
   | NextResponse.ApiError(status) =>
     await Js.Json.null->NextResponse.json(~options={status: status})
-  | e => raise(e)
+  | e => throw(e)
   }
 }

--- a/src/GreenfinityNext_Converter.res
+++ b/src/GreenfinityNext_Converter.res
@@ -15,10 +15,11 @@ module Make = (Config: Config) => {
   external fromJs: Js.t<'a> => Config.t = "%identity"
   let convertFrom = (o: Js.t<'a>): Js.t<'a> =>
     Js.Obj.empty()->Js.Obj.assign(o)->Js.Obj.assign(Config.assignFromStorage(o))
-  let fromStorage = (o): Config.t => switch  o->convertFrom->toJson->Config.t_decode {
-      | Belt.Result.Ok(req) => req
-      | Belt.Result.Error(error) => raise(SerializeError(error))
-      }
+  let fromStorage = (o): Config.t =>
+    switch o->convertFrom->toJson->Config.t_decode {
+    | Belt.Result.Ok(req) => req
+    | Belt.Result.Error(error) => throw(SerializeError(error))
+    }
   let fromStorageOption = (o): option<Config.t> =>
     switch o {
     | Some(o) => o->fromStorage->Some
@@ -30,8 +31,9 @@ module Make = (Config: Config) => {
   let toStorage = (o: Config.t) => o->Config.t_encode->fromJson->convertTo
 }
 
+@deprecated("ResultField module will be removed")
 module ResultField = {
-  let int64 = o => o->Int64.of_string->Int64.float_of_bits
+  // let int64 = o => o->Int64.of_string->Int64.float_of_bits
   let date = o => o->Js.Date.toISOString
   let option = (o, inner) =>
     switch Js.Nullable.isNullable(o) {

--- a/src/GreenfinityNext_Errors.res
+++ b/src/GreenfinityNext_Errors.res
@@ -1,19 +1,17 @@
-type apiErrorStatus = @int
-[
-  | @as(#200) #Success
-  | @as(#400) #BadRequest
-  | @as(#403) #Forbidden
-  | @as(#404) #NotFound
-  | @as(#500) #ServerError
-]
+type apiErrorStatus =
+  | @as(200) Success
+  | @as(400) BadRequest
+  | @as(403) Forbidden
+  | @as(404) NotFound
+  | @as(500) ServerError
 
 let apiErrorFromStatus = status =>
   switch status {
-  | 200 => #Success
-  | 400 => #BadRequest
-  | 403 => #Forbidden
-  | 404 => #NotFound
-  | _ => #ServerError
+  | 200 => Success
+  | 400 => BadRequest
+  | 403 => Forbidden
+  | 404 => NotFound
+  | _ => ServerError
   }
 
 exception ApiError(apiErrorStatus)

--- a/src/GreenfinityNext_Fetch.res
+++ b/src/GreenfinityNext_Fetch.res
@@ -31,11 +31,11 @@ module FetchResponse = {
   let jsonResult = async response => {
     let text = await response.text()
     try Js.Json.parseExn(text)->Result.Ok catch {
-    | Js.Exn.Error(obj) =>
-      switch Js.Exn.name(obj) {
+    | JsExn(obj) =>
+      switch JsExn.name(obj) {
       | Some("SyntaxError") => Result.Error(text)
-      | Some(_) => raise(JsonDecodeError(obj->Js.Exn.message->Option.getWithDefault("")))
-      | None => raise(JsonDecodeError(""))
+      | Some(_) => throw(JsonDecodeError(obj->JsExn.message->Option.getWithDefault("")))
+      | None => throw(JsonDecodeError(""))
       }
     | _ => Result.Error(text)
     }
@@ -56,7 +56,7 @@ let fetchJson = async (url: string, body: Js.Json.t) => {
   let res = await fetch(url, options)
   switch res.ok {
   | true => await res.json()
-  | false => raise(ApiError(res.status->apiErrorFromStatus))
+  | false => throw(ApiError(res.status->apiErrorFromStatus))
   }
 }
 

--- a/src/GreenfinityNext_Middleware.res
+++ b/src/GreenfinityNext_Middleware.res
@@ -4,7 +4,7 @@ module Next = GreenfinityNext_Next
 let default: (Next.Req.t, Next.Res.t, 'a) => 'b = async (req, res, processIt) => {
   let v = await processIt(req->Next.Req.bodyAsJson)
   try {
-    res->Next.Res.statusCode(#Success)
+    res->Next.Res.statusCode(Success)
     res->Next.Res.setHeader("Content-Type", "application/json")
     res->Next.Res.sendJson(v)
     ignore()
@@ -17,10 +17,10 @@ let default: (Next.Req.t, Next.Res.t, 'a) => 'b = async (req, res, processIt) =>
     }
 
   | e => {
-      res->Next.Res.statusCode(#ServerError)
+      res->Next.Res.statusCode(ServerError)
       res->Next.Res.setHeader("Content-Type", "application/json")
       res->Next.Res.sendJson(Js.Json.null)
-      raise(e)
+      throw(e)
     }
   }
 }

--- a/src/GreenfinityNext_Next.res
+++ b/src/GreenfinityNext_Next.res
@@ -12,19 +12,11 @@ module Req = {
 module Res = {
   type t
 
+  type statusCode = GreenfinityNext_Errors.apiErrorStatus
+
   // https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
   @set
-  external statusCode: (
-    t,
-    @int
-    [
-      | @as(200) #Success
-      | @as(400) #BadRequest
-      | @as(403) #Forbidden
-      | @as(404) #NotFound
-      | @as(500) #ServerError
-    ],
-  ) => unit = "statusCode"
+  external statusCode: (t, statusCode) => unit = "statusCode"
 
   @send external setHeader: (t, string, string) => unit = "setHeader"
   @send external sendString: (t, string) => unit = "send"
@@ -300,7 +292,7 @@ module Image = {
     ~layout: [#fixed | #intrinsic | #responsive | #fill]=?,
     ~loader: loaderOptions => string=?,
     ~loading: [
-      | @as("lazy") #lazy_
+      | #"lazy"
       | #eager
     ]=?,
     ~priority: bool=?,

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,9 +478,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@greenfinity/rescript-next@workspace:."
   dependencies:
-    "@greenfinity/rescript-vitest": "npm:^0.1.0"
-    "@greenlabs/ppx-spice": "npm:0.2.2"
-    "@rescript/react": "npm:^0.12.0-alpha.3"
+    "@greenfinity/rescript-vitest": "npm:^0.2.0"
+    "@greenlabs/ppx-spice": "npm:0.2.8"
+    "@rescript/react": "npm:^0.14.0-rc.1"
     "@vercel/functions": "npm:^2.0.0"
     "@vitest/coverage-v8": "npm:2.1.8"
     auto-changelog: "npm:^2.4.0"
@@ -492,33 +492,35 @@ __metadata:
     prettier: "npm:^2.3.1"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
-    rescript: "npm:^11.1.0"
+    rescript: "npm:^12.0.0-beta.4"
     vitest: "npm:^2.1.8"
   peerDependencies:
-    "@greenlabs/ppx-spice": 0.2.2
-    "@rescript/react": ^0.12.0-alpha.3
+    "@greenlabs/ppx-spice": 0.2.8
+    "@rescript/react": ^0.14.0-rc.1
     "@vercel/functions": ^2.0.0
     next: ^15.3.1
     next-auth: ^4.24.11
-    rescript: ^11.1.0
+    rescript: ^12.0.0-beta.4
   languageName: unknown
   linkType: soft
 
-"@greenfinity/rescript-vitest@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@greenfinity/rescript-vitest@npm:0.1.0"
+"@greenfinity/rescript-vitest@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@greenfinity/rescript-vitest@npm:0.2.0"
   dependencies:
     "@vitest/coverage-v8": "npm:^2.1.8"
     jsdom: "npm:^25.0.1"
     vitest: "npm:^2.1.8"
-  checksum: 10/6eef46c39396098ad9610d348ed73733a0ebd5c58d09723f78b42ec8ae3c8896c302ac65bd3098b8e201b4650fa7a5daf75903f2701e4e24a50c76f5906f860c
+  peerDependencies:
+    rescript: ^12.0.0-beta.4
+  checksum: 10/ed97513735fc1a936def1faf66a0b33372ff8af6cdeaeb0fcf7f88d7d6c4d7bca6620af14029c9add494d346aba7cc803184317d74344abf30debef72a9a41ab
   languageName: node
   linkType: hard
 
-"@greenlabs/ppx-spice@npm:0.2.2":
-  version: 0.2.2
-  resolution: "@greenlabs/ppx-spice@npm:0.2.2"
-  checksum: 10/2b403b3a0b2ca2a72c10d661329fdaf4f91d15dc6f18e2fa6dab664714048af6b388f75891cdc9cb995c8b669d9246a96b56c2266c41477d90072335d3c70f38
+"@greenlabs/ppx-spice@npm:0.2.8":
+  version: 0.2.8
+  resolution: "@greenlabs/ppx-spice@npm:0.2.8"
+  checksum: 10/e350900fa3f06d6e931f846cd1378c75312defcfa1fcd1233029985d4194de29ac2677a6f246123c359abab093f5688fcb6f0a4a6d6dba2575e4e64f40286abc
   languageName: node
   linkType: hard
 
@@ -873,13 +875,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rescript/react@npm:^0.12.0-alpha.3":
-  version: 0.12.2
-  resolution: "@rescript/react@npm:0.12.2"
+"@rescript/darwin-arm64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/darwin-arm64@npm:12.0.0-beta.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rescript/darwin-x64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/darwin-x64@npm:12.0.0-beta.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rescript/linux-arm64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/linux-arm64@npm:12.0.0-beta.4"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rescript/linux-x64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/linux-x64@npm:12.0.0-beta.4"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rescript/react@npm:^0.14.0-rc.1":
+  version: 0.14.0
+  resolution: "@rescript/react@npm:0.14.0"
   peerDependencies:
-    react: ">=18.0.0"
-    react-dom: ">=18.0.0"
-  checksum: 10/021f2bdaa611a71a85fd8cd27331b76625236f418f0118006d68707d173dcd5259fdf7f9bf34f3be02118be38616f5b20a3328c0f4e4cccb6c50ae8664e51c0b
+    react: ">=19.0.0"
+    react-dom: ">=19.0.0"
+  checksum: 10/bcfac2d750c0707079ee2369fd418726b73180610dcc65278892f0d797af1e1bddef6b7cce56b2d3a9ff7325ed00510d75cbfa65decc600369c58377c685bfae
+  languageName: node
+  linkType: hard
+
+"@rescript/win32-x64@npm:12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "@rescript/win32-x64@npm:12.0.0-beta.4"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -3092,14 +3129,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rescript@npm:^11.1.0":
-  version: 11.1.3
-  resolution: "rescript@npm:11.1.3"
+"rescript@npm:^12.0.0-beta.4":
+  version: 12.0.0-beta.4
+  resolution: "rescript@npm:12.0.0-beta.4"
+  dependencies:
+    "@rescript/darwin-arm64": "npm:12.0.0-beta.4"
+    "@rescript/darwin-x64": "npm:12.0.0-beta.4"
+    "@rescript/linux-arm64": "npm:12.0.0-beta.4"
+    "@rescript/linux-x64": "npm:12.0.0-beta.4"
+    "@rescript/win32-x64": "npm:12.0.0-beta.4"
+  dependenciesMeta:
+    "@rescript/darwin-arm64":
+      optional: true
+    "@rescript/darwin-x64":
+      optional: true
+    "@rescript/linux-arm64":
+      optional: true
+    "@rescript/linux-x64":
+      optional: true
+    "@rescript/win32-x64":
+      optional: true
   bin:
-    bsc: bsc
-    bstracing: lib/bstracing
-    rescript: rescript
-  checksum: 10/5c96865aca10c6fb541d0e0939a650ef83895db11d918f0815903c16eaa172fa399f76080c12705e270ee096634edcfd350809e311090d57a8bd81d50ea6e532
+    bsc: cli/bsc.js
+    bstracing: cli/bstracing.js
+    rescript: cli/rescript.js
+    rescript-legacy: cli/rescript-legacy.js
+    rescript-tools: cli/rescript-tools.js
+  checksum: 10/2dbb8cbd28e774e5039d4bc2bb91b523c1fdf4ab5fedafcb8fa1ee3367044fba422ea67707265c01dc6782b86d2a14c63c34a5c5c2eb43bffb5f9f73505955a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- update rescript to v12.0.0-beta.4
- update rescript-vitest to 0.2.0
- BREAKING update statusCode to use standard variants instead of polymorphic variants
- deprecate ResultField module in GreenfinityNext_Converter (int64 conversion is removed completely)
- update deprecations