### PR TITLE
Add CacheConfig: typed cache-tag/lifetime functor over Cache

### DIFF
--- a/src/CacheConfig.res
+++ b/src/CacheConfig.res
@@ -1,0 +1,59 @@
+// Typed wrappers around the Next.js `'use cache'` tag + lifetime APIs (Cache),
+// as a functor so each app supplies its own cache-tag type while reusing one
+// implementation. Tags + lifetimes are typed variants rather than raw strings,
+// so cache keys stay typo-proof.
+//
+// The string coercion of a tag lives at the *call site* (the app's
+// `tagToString`): the library can't coerce an abstract functor type to string,
+// and the app's concrete `@as`-string variant can (`(t :> string)`).
+// `DefaultsLife` carries the common lifetime enum so apps rarely define their own.
+//
+// `cacheTag` / `cacheLife` are called INSIDE a `'use cache'` component;
+// `updateTag` / `revalidateTag` bust a tag from a mutation server action.
+
+module type CacheConfig = {
+  type tag
+  type life
+  let tagToString: tag => string
+  let lifeToString: life => string
+}
+
+module DefaultsLife = {
+  type life =
+    | @as("seconds") Seconds
+    | @as("minutes") Minutes
+    | @as("hours") Hours
+    | @as("days") Days
+    | @as("max") Max
+
+  let lifeToString = (life: life) => (life :> string)
+}
+
+module Make = (Config: CacheConfig) => {
+  type tag = Config.tag
+  type life = Config.life
+  let tagToString = Config.tagToString
+  let lifeToString = Config.lifeToString
+  let cacheTag = tag => tag->tagToString->Cache.cacheTag
+  let cacheLife = life => life->lifeToString->Cache.cacheLife
+  let updateTag = tag => tag->tagToString->Cache.updateTag
+  let revalidateTag = (tag, ~profile: Cache.revalidateProfile) =>
+    tag->tagToString->Cache.revalidateTag(~profile)
+}
+
+// Example usage — an app supplies its own cache-tag type, then applies `Make`.
+// The config must be a *named* module (the functor result mentions its `tag` /
+// `life`, so an inline struct gives "parameter cannot be eliminated");
+// `include DefaultsLife` takes the standard lifetime enum as the default.
+//
+//   module MyCacheConfigBase = {
+//     include DefaultsLife
+//     type tag = | @as("public-content") PublicContent
+//     let tagToString = (tag: tag) => (tag :> string)
+//   }
+//   module MyCacheConfig = Make(MyCacheConfigBase)
+//
+//   // tag + lifetime values come from the Base module:
+//   MyCacheConfig.cacheTag(MyCacheConfigBase.PublicContent)
+//   MyCacheConfig.cacheLife(MyCacheConfigBase.Max)
+//   MyCacheConfig.updateTag(MyCacheConfigBase.PublicContent)


### PR DESCRIPTION
Adds `CacheConfig` (`GreenfinityNext.CacheConfig`) — a functor wrapping the `Cache` `'use cache'` tag + lifetime bindings with typed variants, so each app supplies its own cache-tag type while sharing one implementation. (Lifts the per-app helper that lived in njc-2026's `Content_Cache`.)

### API

```rescript
module type CacheConfig = {
  type tag
  type life
  let tagToString: tag => string
  let lifeToString: life => string
}

module DefaultsLife = {                       // @as("seconds") Seconds … @as("max") Max
  type life = Seconds | Minutes | Hours | Days | Max
  let lifeToString = (life: life) => (life :> string)
}

module Make = (Config: CacheConfig) => {
  // re-exports tag/life/tagToString/lifeToString + cacheTag/cacheLife/updateTag/revalidateTag
}
```

### Why `tagToString` in the config (not a coercion inside the functor)

`(tag :> string)` is compile-checked and only works on a concrete `@as`-string variant; an **abstract** functor type (`Config.tag`) "is not a subtype of string", so the coercion has to happen where the concrete type is known — the app's `tagToString`. There's no built-in "coercible-to-string" constraint and no type classes, so passing the conversion is the idiomatic stand-in. `DefaultsLife` carries the common lifetime enum so apps `include` it.

### Usage

The config must be a **named** module (the functor result mentions `Config.tag`/`Config.life`, so an inline struct gives "parameter cannot be eliminated"):

```rescript
module MyCacheConfigBase = {
  include DefaultsLife
  type tag = | @as("public-content") PublicContent
  let tagToString = (tag: tag) => (tag :> string)
}
module MyCacheConfig = Make(MyCacheConfigBase)
MyCacheConfig.cacheTag(MyCacheConfigBase.PublicContent)
```