### PR TITLE
NextServer.NextResponse: add redirect and the response cookie store

### DIFF
--- a/src/NextServer.res
+++ b/src/NextServer.res
@@ -67,6 +67,17 @@ module NextResponse = {
   }
   @module("next/server") @scope("NextResponse")
   external next: nextOptions => t = "next"
+
+  /* Redirect to an absolute URL (build it from the request's nextUrl.origin).
+   * Defaults to 307; pass ~status for 301/302/308. */
+  @module("next/server") @scope("NextResponse")
+  external redirect: (string, ~status: int=?) => t = "redirect"
+
+  /* The RESPONSE cookie store (Set-Cookie): what a middleware/route handler
+   * sets on the way out — distinct from the request store on NextRequest.t.
+   * The shared Cookies surface (get/set/delete/…) fits both. */
+  @get
+  external cookies: t => GreenfinityNext.Cookies.t = "cookies"
 }
 
 module Middleware = {


### PR DESCRIPTION
Two members the `NextResponse` binding was missing, extracted from njc-2026's sc-50 language-cookie proxy where they were local bindings:

- `redirect`: the static constructor, next to `json`/`next` (`@scope("NextResponse")`). Takes an absolute URL; 307 by default, `~status` for the permanent variants.
- `cookies`: the RESPONSE cookie store (the Set-Cookie side a middleware/route handler writes) as a `@get` on `NextResponse.t` — distinct from the request store already on `NextRequest.t`; the shared `Cookies` surface (get/set/delete/…) fits both.

Purely additive.